### PR TITLE
Changed processing order and added error check

### DIFF
--- a/api.go
+++ b/api.go
@@ -41,16 +41,19 @@ func generateRequest(method string, path string, paramStruct interface{}) (*http
 }
 
 func generateRequestWithToken(method string, path string, paramStruct interface{}) (*http.Request, error) {
-	req, err := generateRequest(method, path, paramStruct)
 
 	token := os.Getenv("PIXELA_USER_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("token is not set. please specify your token by PIXELA_USER_TOKEN environment variable")
 	}
 
-	req.Header.Set("X-USER-TOKEN", token)
+	req, err := generateRequest(method, path, paramStruct)
 
-	return req, err
+	if err == nil {
+		req.Header.Set("X-USER-TOKEN", token)
+	}
+
+	return rep, err
 }
 
 func doRequest(req *http.Request) error {

--- a/api.go
+++ b/api.go
@@ -53,7 +53,7 @@ func generateRequestWithToken(method string, path string, paramStruct interface{
 		req.Header.Set("X-USER-TOKEN", token)
 	}
 
-	return rep, err
+	return req, err
 }
 
 func doRequest(req *http.Request) error {


### PR DESCRIPTION
First checked the token and delayed generateRequest() execution. (order by processing weight.)
Added error check because req.Header.Set() generates a panic when return value of generateRequest() is nil, err.
As a result, the processing order is similar to generateRequest().