### PR TITLE
Fix secret feature, flag

### DIFF
--- a/graphs.go
+++ b/graphs.go
@@ -27,7 +27,7 @@ type createGraphCommand struct {
 	Color          string `short:"c" long:"color" description:"The display color of the pixel in the pixelation graph." choice:"shibafu" choice:"momiji" choice:"sora" choice:"ichou" choice:"ajisai" choice:"kuro" required:"true"`
 	Timezone       string `short:"z" long:"timezone" description:"The timezone for handling this graph"`
 	SelfSufficient string `short:"s" long:"self-sufficient" description:"If SVG graph with this field 'increment' or 'decrement' is referenced, Pixel of this graph itself will be incremented or decremented." choice:"increment" choice:"decrement" choice:"none"`
-	IsSecret       *bool  `short:"x" long:"is-secret" description:"When this property is specified, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
+	Secret         *bool  `short:"x" long:"secret" description:"When this property is specified, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
 }
 
 type createGraphParam struct {
@@ -61,8 +61,8 @@ type updateGraphCommand struct {
 	Timezone       string   `short:"z" long:"timezone" description:"The timezone for handling this graph"`
 	PurgeCacheURLs []string `short:"p" long:"purge-cache-urls" description:"The URL to send the purge request to purge the cache when the graph is updated. Multiple params can be specified."`
 	SelfSufficient string   `short:"s" long:"self-sufficient" description:"If SVG graph with this field 'increment' or 'decrement' is referenced, Pixel of this graph itself will be incremented or decremented." choice:"increment" choice:"decrement" choice:"none"`
-	IsSecret       *bool    `short:"x" long:"is-secret" description:"When this property is true, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
-	IsPublish      *bool    `short:"r" long:"is-publish" description:"When this property is specified, the graph will be released to the public. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
+	Secret         *bool    `short:"x" long:"secret" description:"When this property is true, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
+	Publish        *bool    `short:"r" long:"publish" description:"When this property is specified, the graph will be released to the public. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
 }
 type updateGraphParam struct {
 	Name           string   `json:"name"`
@@ -124,7 +124,7 @@ func generateCreateGraphRequest(cG *createGraphCommand) (*http.Request, error) {
 		Color:          cG.Color,
 		Timezone:       cG.Timezone,
 		SelfSufficient: cG.SelfSufficient,
-		IsSecret:       cG.IsSecret,
+		IsSecret:       cG.Secret,
 	}
 
 	req, err := generateRequestWithToken(
@@ -220,18 +220,18 @@ func generateUpdateGraphRequest(uG *updateGraphCommand) (*http.Request, error) {
 		return nil, fmt.Errorf("you can only specify up to five URLs for PurgeCacheURLs param")
 	}
 
-	if uG.IsSecret != nil && uG.IsPublish != nil && *uG.IsSecret && *uG.IsPublish {
-		return nil, fmt.Errorf("specify either --is-secret or --is-publish")
+	if uG.Secret != nil && uG.Publish != nil && *uG.Secret && *uG.Publish {
+		return nil, fmt.Errorf("specify either --secret or --publish")
 	}
 
 	var isSecret *bool
 	falseValue := false
-	if uG.IsPublish != nil && *uG.IsPublish {
+	if uG.Publish != nil && *uG.Publish {
 		isSecret = &falseValue
-	} else if uG.IsSecret == nil {
+	} else if uG.Secret == nil {
 		// no ops, isSecret value is nil as.
-	} else if *uG.IsSecret {
-		isSecret = uG.IsSecret
+	} else if *uG.Secret {
+		isSecret = uG.Secret
 	}
 
 	paramStruct := &updateGraphParam{

--- a/graphs.go
+++ b/graphs.go
@@ -27,7 +27,7 @@ type createGraphCommand struct {
 	Color          string `short:"c" long:"color" description:"The display color of the pixel in the pixelation graph." choice:"shibafu" choice:"momiji" choice:"sora" choice:"ichou" choice:"ajisai" choice:"kuro" required:"true"`
 	Timezone       string `short:"z" long:"timezone" description:"The timezone for handling this graph"`
 	SelfSufficient string `short:"s" long:"self-sufficient" description:"If SVG graph with this field 'increment' or 'decrement' is referenced, Pixel of this graph itself will be incremented or decremented." choice:"increment" choice:"decrement" choice:"none"`
-	IsSecret       *bool  `short:"x" long:"is-secret" description:"When this property is true, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
+	IsSecret       *bool  `short:"x" long:"is-secret" description:"When this property is specified, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
 }
 
 type createGraphParam struct {
@@ -62,6 +62,7 @@ type updateGraphCommand struct {
 	PurgeCacheURLs []string `short:"p" long:"purge-cache-urls" description:"The URL to send the purge request to purge the cache when the graph is updated. Multiple params can be specified."`
 	SelfSufficient string   `short:"s" long:"self-sufficient" description:"If SVG graph with this field 'increment' or 'decrement' is referenced, Pixel of this graph itself will be incremented or decremented." choice:"increment" choice:"decrement" choice:"none"`
 	IsSecret       *bool    `short:"x" long:"is-secret" description:"When this property is true, the graph is hidden on the list page. This is a limited feature. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
+	IsPublish      *bool    `short:"r" long:"is-publish" description:"When this property is specified, the graph will be released to the public. For detail, see https://github.com/a-know/Pixela/wiki/How-to-support-Pixela-by-Patreon-%EF%BC%8F-Use-Limited-Features"`
 }
 type updateGraphParam struct {
 	Name           string   `json:"name"`
@@ -219,6 +220,20 @@ func generateUpdateGraphRequest(uG *updateGraphCommand) (*http.Request, error) {
 		return nil, fmt.Errorf("you can only specify up to five URLs for PurgeCacheURLs param")
 	}
 
+	if uG.IsSecret != nil && uG.IsPublish != nil && *uG.IsSecret && *uG.IsPublish {
+		return nil, fmt.Errorf("specify either --is-secret or --is-publish")
+	}
+
+	var isSecret *bool
+	falseValue := false
+	if uG.IsPublish != nil && *uG.IsPublish {
+		isSecret = &falseValue
+	} else if uG.IsSecret == nil {
+		// no ops, isSecret value is nil as.
+	} else if *uG.IsSecret {
+		isSecret = uG.IsSecret
+	}
+
 	paramStruct := &updateGraphParam{
 		Name:           uG.Name,
 		Unit:           uG.Unit,
@@ -226,7 +241,7 @@ func generateUpdateGraphRequest(uG *updateGraphCommand) (*http.Request, error) {
 		Timezone:       uG.Timezone,
 		PurgeCacheURLs: uG.PurgeCacheURLs,
 		SelfSufficient: uG.SelfSufficient,
-		IsSecret:       uG.IsSecret,
+		IsSecret:       isSecret,
 	}
 
 	req, err := generateRequestWithToken(

--- a/graphs.go
+++ b/graphs.go
@@ -221,7 +221,7 @@ func generateUpdateGraphRequest(uG *updateGraphCommand) (*http.Request, error) {
 	}
 
 	if uG.Secret != nil && uG.Publish != nil && *uG.Secret && *uG.Publish {
-		return nil, fmt.Errorf("specify either --secret or --publish")
+		return nil, fmt.Errorf("specify either --secret,-x or --publish,-r")
 	}
 
 	var isSecret *bool

--- a/graphs_test.go
+++ b/graphs_test.go
@@ -182,7 +182,7 @@ func TestGenerateCreateGraphRequest(t *testing.T) {
 		Color:          testColor,
 		Timezone:       testTimezone,
 		SelfSufficient: testSelfSufficient,
-		IsSecret:       &testIsSecret,
+		Secret:         &testIsSecret,
 	}
 
 	// run
@@ -438,8 +438,8 @@ func TestGenerateUpdateGraphRequestWithSecretAndPublish(t *testing.T) {
 		Timezone:       testTimezone,
 		PurgeCacheURLs: testPurgeCacheURLs,
 		SelfSufficient: testSelfSufficient,
-		IsSecret:       &testIsSecret,
-		IsPublish:      &testIsPublish,
+		Secret:         &testIsSecret,
+		Publish:        &testIsPublish,
 	}
 
 	// run
@@ -476,7 +476,7 @@ func TestGenerateUpdateGraphRequestWithSecret(t *testing.T) {
 		Timezone:       testTimezone,
 		PurgeCacheURLs: testPurgeCacheURLs,
 		SelfSufficient: testSelfSufficient,
-		IsSecret:       &testIsSecret,
+		Secret:         &testIsSecret,
 	}
 
 	// run
@@ -527,8 +527,8 @@ func TestGenerateUpdateGraphRequestWithPublish(t *testing.T) {
 		Timezone:       testTimezone,
 		PurgeCacheURLs: testPurgeCacheURLs,
 		SelfSufficient: testSelfSufficient,
-		IsSecret:       nil,
-		IsPublish:      &testIsPublish,
+		Secret:         nil,
+		Publish:        &testIsPublish,
 	}
 
 	// run


### PR DESCRIPTION
against #15 

### When we want to make graph private
- before
    - `pi graphs update -u a-know -g test-graph --is-secret`
- after
    - `pi graphs update -u a-know -g test-graph --secret`

### When we want to make graph publish
- before
    - (could not do it...)
- after
    - `pi graphs update -u a-know -g test-graph --publish`