### PR TITLE
Fix name scope of buffer declaration

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
 )
 
 func generateRequest(method string, path string, paramStruct interface{}) (*http.Request, error) {
@@ -18,17 +17,17 @@ func generateRequest(method string, path string, paramStruct interface{}) (*http
 	}
 
 	var reqBody io.Reader
-	buffer := &bytes.Buffer{}
 	if paramStruct != nil {
+		buffer := &bytes.Buffer{}
 		encoder := json.NewEncoder(buffer)
 		encoder.SetEscapeHTML(false)
 		err := encoder.Encode(paramStruct)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to marshal options to json : %s", err)
 		}
-		str := string(buffer.Bytes())
-		str = strings.TrimRight(str, "\n")
-		reqBody = bytes.NewBuffer([]byte(str))
+		b := buffer.Bytes()
+		b = bytes.TrimRight(b, "\n")
+		reqBody = bytes.NewBuffer(b)
 	}
 
 	req, err := http.NewRequest(


### PR DESCRIPTION
The buffer declaration is only used in if statements.
I confined the name scope of the buffer declaration inside the if statement.