### PR TITLE
:books: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Installation
 
-    % go get github.com/a-know/pi/cmd/pi
+    % go install github.com/a-know/pi/cmd/pi@latest
 
 OR
 


### PR DESCRIPTION
Since go 1.18, the go get command can no longer be used for installation, so it has been replaced by the go install command.